### PR TITLE
update before installing

### DIFF
--- a/.github/workflows/updateCargoTrackerToOpenLibertyOnAks.yml
+++ b/.github/workflows/updateCargoTrackerToOpenLibertyOnAks.yml
@@ -153,6 +153,7 @@ jobs:
             - name: Verify that the app is update
               run: |
                 # install dependencies
+                sudo apt-get update
                 sudo apt-get install libegl1\
                       libhyphen0\
                       libopus0\

--- a/.github/workflows/updateCargoTrackerToWlsOnAks.yml
+++ b/.github/workflows/updateCargoTrackerToWlsOnAks.yml
@@ -179,6 +179,7 @@ jobs:
             - name: Verify that the app is update
               run: |
                 # install dependencies
+                sudo apt-get update
                 sudo apt-get install libegl1\
                       libopus0\
                       libwoff1\


### PR DESCRIPTION
Fix update CargoTracker pipelines for WLS & OpenLiberty on AKS

Test runs:

WLS on AKS: https://github.com/zhengchang907/javaland-javaee/actions/runs/1961829676
OpenLiberty on AKS: https://github.com/zhengchang907/javaland-javaee/actions/runs/1961579160